### PR TITLE
Eliminate UI replacement delay during scene switches

### DIFF
--- a/src/HUDReplacer/HUDReplacer.cs
+++ b/src/HUDReplacer/HUDReplacer.cs
@@ -139,6 +139,10 @@ public partial class HUDReplacer : MonoBehaviour
     private void OnLevelGUIReady(GameScenes scene)
     {
         Debug.Log("HUDReplacer: GUI Ready for scene: " + scene);
+        // Immediate refresh to avoid default UI being visible during the transition.
+        replacedTextureIds.Clear();
+        RefreshAll();
+
         StartCoroutine(DelayedRefresh(3.0f));
     }
 


### PR DESCRIPTION
The change adds an immediate call to `RefreshAll()` (after clearing `replacedTextureIds`) within the `OnLevelGUIReady` event handler. This ensures that UI textures are replaced as soon as the scene is ready, rather than waiting for the previous 3-second delay. The delay is kept as a secondary, thorough refresh to ensure compatibility with other mods.

---
*PR created automatically by Jules for task [17636127515789587616](https://jules.google.com/task/17636127515789587616) started by @Aeurias*